### PR TITLE
fix：画像ローディング後にコンポーネントを表示する仕様の修正.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,13 @@
     base: '/example/book-reader',
     ```
 
-- `imgSrcPath.ts`で画像パス（`imgSrcPath`）と拡張子（`extendsType`）の設定を調整
+- `imgSrcPath.ts`で以下を調整
+    - 画像パス（`imgSrcPath`）と、必要に応じて拡張子（`extendsType`）の設定を調整
 
-- `PageComponents.tsx`の以下を調整
-    - 最後のページ番号とコンテンツ名を指定
-        - `const lastPageNum: number = 最後のページ番号（コンテンツの画像データの最大ナンバー）;`
-        - `const documentTitle: string = 'コンテンツ名を指定';`
-        - 【任意】ドキュメントが縦書き（右開き）の場合は`verticalWritingMode`を`true`にする
-    - 最初のページの画像パスの指定（※ナンバリングの先頭に 0 or 00 などが前置する場合）
-        - `firstPageImgSrc` 部分で指定している画像データのナンバリング部分を調整
+- `PageComponents.tsx`で最後のページ番号とコンテンツ名を指定
+    - `const lastPageNum: number = 最後のページ番号（コンテンツの画像データの最大ナンバー）;`
+    - `const documentTitle: string = 'コンテンツ名を指定';`
+    - 【任意】ドキュメントが縦書き（右開き）の場合は`verticalWritingMode`を`true`にする
 
 - `usePagination.ts`と`useWaitLoadingAllImgs.ts`の以下を調整
     - 【任意】画像データファイルのナンバリング先頭に 0 or 00 などが前置する場合（例：画像データ名のナンバリング部分が「001 ~ 009」「010 ~ 099」「100 ~ 」という形）は`useSetImgSrc.ts`（`src\hook\useSetImgSrc.ts`）カスタムフックを使用する（当該カスタムフックは現状コメントアウト）

--- a/src/PageComponents.tsx
+++ b/src/PageComponents.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { memo, useEffect, useLayoutEffect, useState } from "react";
-import { extendsType, imgSrcPath } from "./utils/imgSrcPath";
 import { FirstPage } from "./libs/FirstPage";
 import { FinalPage } from "./libs/FinalPage";
 import { MultiPages } from "./libs/MultiPages";
@@ -13,9 +12,6 @@ import { useToggleClass } from "./hook/useToggleClass";
 import { useWaitLoadingAllImgs } from "./hook/useWaitLoadingAllImgs";
 
 export const PageComponents = memo(() => {
-    /* 最初のページの画像パス（画像データのナンバリング部分を調整）*/
-    const firstPageImgSrc: string = `${imgSrcPath}1.${extendsType}`;
-
     const lastPageNum: number = 100;
     const documentTitle: string = 'ドキュメント XXXX';
 
@@ -43,7 +39,17 @@ export const PageComponents = memo(() => {
 
     /* 全画像の読込を監視 */
     useEffect(() => {
-        WaitLoadingAllImgs(lastPageNum, setLoading);
+        setLoading(true);
+
+        WaitLoadingAllImgs(lastPageNum);
+
+        const firstPageImg: HTMLImageElement | null = document.querySelector('.wrapperSec img');
+        firstPageImg?.addEventListener('load', () => setLoading(false));
+
+        /* useEffect のクリーンアップ処理 */
+        return () => {
+            firstPageImg?.removeEventListener('load', () => setLoading(false));
+        }
     }, []);
 
     return (
@@ -59,7 +65,6 @@ export const PageComponents = memo(() => {
                                             verticalWritingMode={verticalWritingMode}
                                             pagerSpeed={pagerSpeed}
                                             isPageNum={isPageNum}
-                                            firstPageImgSrc={firstPageImgSrc}
                                             documentTitle={documentTitle}
                                             ToggleClass={ToggleClass}
                                             thePostsPagination={thePostsPagination}
@@ -93,7 +98,6 @@ export const PageComponents = memo(() => {
                                 pagerSpeed={pagerSpeed}
                                 isPageNum={isPageNum}
                                 lastPageNum={lastPageNum}
-                                firstPageImgSrc={firstPageImgSrc}
                                 documentTitle={documentTitle}
                                 PrevPage={PrevPage}
                                 ToggleClass={ToggleClass}

--- a/src/hook/useWaitLoadingAllImgs.ts
+++ b/src/hook/useWaitLoadingAllImgs.ts
@@ -2,15 +2,11 @@ import { extendsType, imgSrcPath } from "../utils/imgSrcPath";
 // import { useSetImgSrc } from "./useSetImgSrc";
 
 export const useWaitLoadingAllImgs = () => {
-    const WaitLoadingAllImgs: (lastPageNum: number, setLoading: React.Dispatch<React.SetStateAction<boolean>>) => void = (
-        lastPageNum: number,
-        setLoading: React.Dispatch<React.SetStateAction<boolean>>
-    ) => {
-        setLoading(true);
-
+    const WaitLoadingAllImgs: (lastPageNum: number) => void = (lastPageNum: number) => {
         /* 画像データ名のナンバリング部分が「001 ~ 009」「010 ~ 099」「100 ~ 」という形の場合に使用するカスタムフック */
         // const { setImgSrc } = useSetImgSrc();
 
+        /* 全画像に対するフェッチ処理 */
         const _fetchImgSrc: (i: number) => Promise<number | undefined> = async (i: number) => {
             // const res: Response = await fetch(setImgSrc(i));
             const res: Response = await fetch(`${location.origin}${imgSrcPath}${i}.${extendsType}`);
@@ -19,12 +15,6 @@ export const useWaitLoadingAllImgs = () => {
                 if (!res.ok) {
                     throw new Error(`_fetchImgSrc was failed. status:${res.status}`);
                 }
-
-                /* 最後の画像データへのフェッチ成功時にローディング解除 */
-                if (i === lastPageNum) {
-                    setLoading(false);
-                }
-
                 return res.status;
             } catch (error) {
                 console.error(error);

--- a/src/libs/FirstPage.tsx
+++ b/src/libs/FirstPage.tsx
@@ -1,17 +1,17 @@
 import { FC, memo } from 'react';
+import firstPageImgSrc from "../../public/catalog-img/catalog_all_page_1.jpg";
 
 type pageProps = {
     verticalWritingMode: boolean;
     pagerSpeed: number;
     isPageNum: number;
-    firstPageImgSrc: string;
     documentTitle: string;
     ToggleClass: (el: HTMLElement, className: string) => void;
     thePostsPagination: (page: number) => void;
 }
 
 export const FirstPage: FC<pageProps> = memo((props) => {
-    const { verticalWritingMode, pagerSpeed, isPageNum, firstPageImgSrc, documentTitle, ToggleClass, thePostsPagination } = props;
+    const { verticalWritingMode, pagerSpeed, isPageNum, documentTitle, ToggleClass, thePostsPagination } = props;
 
     return (
         <button onClick={(elm) => {

--- a/src/libs/SinglePage.tsx
+++ b/src/libs/SinglePage.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
-import { FC, memo, useLayoutEffect, useState } from "react";
+import { FC, memo, useEffect, useState } from "react";
+import firstPageImgSrc from "../../public/catalog-img/catalog_all_page_1.jpg";
 
 type singlePageType = {
     verticalWritingMode: boolean;
@@ -7,27 +8,26 @@ type singlePageType = {
     isPageNum: number;
     lastPageNum: number;
     documentTitle: string;
-    firstPageImgSrc: string;
     PrevPage: (isPageNum: number) => string;
     ToggleClass: (el: HTMLElement, className: string) => void;
     thePostsPagination: (page: number) => void;
 }
 
 export const SinglePage: FC<singlePageType> = memo((props) => {
-    const { verticalWritingMode, pagerSpeed, isPageNum, lastPageNum, documentTitle, firstPageImgSrc, PrevPage, ToggleClass, thePostsPagination } = props;
+    const { verticalWritingMode, pagerSpeed, isPageNum, lastPageNum, documentTitle, PrevPage, ToggleClass, thePostsPagination } = props;
 
     /**
      * SinglePage.tsx（スマートフォン用のコンポーネント）は 1ページ表示仕様なのでページ送り用の button 要素を2つ用意して画像の半々で分割しているので他のページとは異なる処理方法（*1）になっている。
      * *1：ページ画像のStateを用意したり、ページ画像に直接アニメーションclass を付与したり
     */
 
-    /* useLayoutEffect でレンダリング前に要素（targetImgEl：.singlePageImg）を認知させておくことで最初のページにも class付与（ページめくり）の処理を反映 */
     const [isImgEl, setImgEl] = useState<HTMLImageElement | null>(null);
-    useLayoutEffect(() => {
+
+    useEffect(() => {
+        /* 最初のページにも class付与（ページめくり）の処理を反映 */
         const targetImgEl: HTMLImageElement | null = document.querySelector('.singlePageImg');
         setImgEl(targetImgEl);
-    }, [isPageNum]);
-
+    }, [firstPageImgSrc, isPageNum]);
 
     return (
         <SinglePageWrapper>


### PR DESCRIPTION
- 画像ローディング後にコンポーネントを表示する仕様の修正
  - 最初の画像を静的アセットとして扱う（`FirstPage.tsx`, `SinglePage.tsx`）
  - 最初の画像を読み込んでからローディングStateを更新
  ```
    useEffect(() => {
          setLoading(true);
  
          WaitLoadingAllImgs(lastPageNum); // 全画像のフェッチ
  
          const firstPageImg: HTMLImageElement | null = document.querySelector('.wrapperSec img');
          firstPageImg?.addEventListener('load', () => setLoading(false)); // 最初の画像を読み込んでからローディングStateを更新
  
          /* useEffect のクリーンアップ処理 */
          return () => {
              firstPageImg?.removeEventListener('load', () => setLoading(false));
          }
     }, []);
  ```
  - `useWaitLoadingAllImgs.ts`にて不要となったローディングStateの更新に関する処理を削除